### PR TITLE
Allow limiting via access

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,3 +75,38 @@ Auth.prototype.allow_publish = function(user, _package, cb) { // jscs:ignore req
     }
   }
 };
+
+Auth.prototype.allow_access = function(user, _package, cb) { // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
+  if (_package.gitlab) {
+    var packageScopeOwner = false;
+    var packageOwner = false;
+
+    user.real_groups.forEach(function(item) { // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
+      if (item === _package.name) {
+        packageOwner = true;
+        return false;
+      } else {
+        if (_package.name.indexOf('@') === 0) {
+          if (item === _package.name.slice(1, _package.name.lastIndexOf('/'))) {
+            packageScopeOwner = true;
+            return false;
+          }
+        }
+      }
+    });
+
+    if (packageOwner === true) {
+      return cb(null, false);
+    } else {
+      if (packageScopeOwner === true) {
+        return cb(null, false);
+      } else {
+        if (_package.name.indexOf('@') === 0) {
+          return cb(httperror[403]('must be owner of package-scope'));
+        } else {
+          return cb(httperror[403]('must be owner of package-name'));
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Thank you @bufferoverflow for this epic work! This is something I actually have been wanting to implement for a while

I am trying to allow limit access to the repositories via the same gitlab Authentication, I managed to very hackily copy and paste the allow_publish.

I know this is less than ideal but what I am trying to do is the following.

Figure out how we can allow publish to user's that have master access to groups. Allow view access to anyone that has view access via gitlab.

Is this something you think is possible and any tips on how "best" to achieve this? From what I can see the auth plugins are pretty limited there doesn't seem to be an easy way to re-authenticate or dynamically pull the groups at publish/access time?

I still don't understand why the standard `access: $authenticated` doesn't actually work without copying and pasting these methods?
