### PR TITLE
Allow alone setup with docker compose and fix python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ RUN apk --no-cache add openssl && \
     wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
     chmod +x /usr/local/bin/dumb-init && \
     apk del openssl
-
+    
+RUN apk add --no-cache --virtual .gyp \
+        python \
+        make \
+        g++
+        
 ENV APPDIR /usr/local/app
 
 WORKDIR $APPDIR
@@ -16,11 +21,14 @@ ENV NODE_ENV=production
 
 RUN npm config set registry http://registry.npmjs.org/ && \
     npm install -g verdaccio@2.7.3 && \
-    npm install -g verdaccio-gitlab@latest
+    npm install -g verdaccio-gitlab@latest && \
+    apk del .gyp
 
 RUN mkdir -p /verdaccio/storage /verdaccio/conf
 
 ADD docker-verdaccio-gitlab.config.yaml /verdaccio/conf/config.yaml
+
+RUN chmod -R 777 /verdaccio/storage /verdaccio/conf
 
 RUN addgroup -S verdaccio && adduser -S -G verdaccio verdaccio && \
     chown -R verdaccio:verdaccio "$APPDIR" && \

--- a/docker-compose.alone-sample.yaml
+++ b/docker-compose.alone-sample.yaml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  verdaccio:
+    image: verdaccio/verdaccio
+    restart: always
+    ports:
+      - '4873:4873'
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - verdaccio:/verdaccio
+
+volumes:
+  verdaccio:


### PR DESCRIPTION
- The current docker-compose is included gitlab service setup, we can remove and add a single service as an example.
- while building, node-gyp complains not having python, so we add dependencies to the node:alpine
