### PR TITLE
fix: improve auth handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "babel src/ --out-dir lib/ --copy-files --ignore ___tests___ --source-maps",
     "commitmsg": "commitlint -e $GIT_PARAMS",
-    "license": "license-checker --onlyAllow 'Apache-2.0; BSD; BSD-2-Clause; BSD-3-Clause; ISC; MIT; Unlicense; WTFPL' --production",
-    "lint": "eslint index.js && eclint check && markdownlint README.md",
+    "license": "license-checker --onlyAllow 'Apache-2.0; BSD; BSD-2-Clause; BSD-3-Clause; ISC; MIT; Unlicense; WTFPL; CC-BY-3.0; CC0-1.0' --production",
+    "lint": "eslint index.js && eclint check $(git ls-files) && markdownlint README.md",
     "prepublish": "in-publish && npm run lint && npm run build || not-in-publish",
     "release:major": "changelog -M && git commit -a -m 'docs: updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",
     "release:minor": "changelog -m && git commit -a -m 'docs: updated CHANGELOG.md' && npm version minor && git push origin && git push origin --tags",
@@ -46,6 +46,7 @@
     "@verdaccio/types": "^3.0.0",
     "gitlab": "^3.4.2",
     "global-tunnel-ng": "^2.1.1",
+    "http-errors": "^1.6.3",
     "verdaccio": "^3.1.1"
   },
   "devDependencies": {

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -3,7 +3,7 @@
 // @flow
 
 import Gitlab from 'gitlab';
-import {httperror} from 'http-errors';
+import httperror from 'http-errors';
 import type { PackageAccess, Config, Logger, Callback } from '@verdaccio/types';
 
 export default class VerdaccioGitLab {
@@ -33,67 +33,82 @@ export default class VerdaccioGitLab {
   }
 
   authenticate(user: string, password: string, cb: Callback) {
+    this.logger.trace('[gitlab] authenticate called for user:', user);
 
-    var GitlabAPI = new Gitlab({
+    const GitlabAPI = new Gitlab({
       url:   this.config.url,
       token: password
     });
 
-    GitlabAPI.Users.current().then((response) => {
-      if (user !== response.username) return cb(httperror[403]('wrong gitlab username'));
-      var ownedGroups = [user];
-      GitlabAPI.Groups.all({'owned': 'true'}).then((groups) => {
-        groups.forEach(function(item) {
-          if (item.path === item.full_path) {
-            ownedGroups.push(item.path);
+    GitlabAPI.Users.current().then(response => {
+      if (user !== response.username) { return cb(httperror[401]('wrong gitlab username')); }
+
+      // Set the groups of an authenticated user to themselves and all gitlab projects of which they are an owner
+      let ownedGroups = [user];
+      GitlabAPI.Groups.all({'owned': 'true'}).then(groups => {
+        for (let group of groups) {
+          if (group.path === group.full_path) {
+            ownedGroups.push(group.path);
           }
-        });
+        }
+
+        this.logger.debug('[gitlab] user:', user, 'authenticated, with groups:', ownedGroups);
         cb(null, ownedGroups);
       });
     }).
     catch(error => {
-      if (error) return cb('Personal access token invalid');
+      this.logger.debug('[gitlab] error authenticating:', error.error || null);
+      if (error) { return cb(httperror[401]('personal access token invalid')); }
     });
   }
 
   adduser(user: string, password: string, cb: Callback) {
-    cb(null, false);
+    this.logger.trace('[gitlab] adduser called for user:', user);
+    cb(null, true);
   }
 
-  allow_access(user, _package:  PackageAccess, cb: Callback) {
-    if (!_package.gitlab) return cb();
+  allow_access(user, _package: PackageAccess, cb: Callback) {
+    if (!_package.gitlab) { return cb(); }
     if (_package.access.includes('$authenticated') && user.name !== undefined) {
+      this.logger.debug('[gitlab] allow user:', user.name, 'access to package:', _package.name);
       return cb(null, true);
     } else {
+      this.logger.debug('[gitlab] pass-through unauthenticated access package:', _package.name);
       return cb(null, false);
     }
   }
 
   allow_publish(user, _package: PackageAccess, cb: Callback) { // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
-    if (!_package.gitlab) return cb();
-    var packageScopeOwner = false;
-    var packageOwner = false;
+    if (!_package.gitlab) { return cb(); }
+    let packageScopeOwner = false;
+    let packageOwner = false;
 
-    user.real_groups.forEach(function(item) { // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
-      if (item === _package.name) {
+    // Only allow to publish packages when:
+    //  - the package has exactly the same name as one of the user groups, or
+    //  - the package scope is the same as one of the user groups
+    for (let real_group of user.real_groups) { // jscs:ignore requireCamelCaseOrUpperCaseIdentifiers
+      if (real_group === _package.name) {
         packageOwner = true;
-        return false;
+        break;
       } else {
         if (_package.name.indexOf('@') === 0) {
-          if (item === _package.name.slice(1, _package.name.lastIndexOf('/'))) {
+          if (real_group === _package.name.slice(1, _package.name.lastIndexOf('/'))) {
             packageScopeOwner = true;
-            return false;
+            break;
           }
         }
       }
-    });
+    }
 
     if (packageOwner === true) {
+      this.logger.debug('[gitlab] user:', user.name, 'allowed to publish package:', _package.name, 'as owner of package-name');
       return cb(null, false);
     } else {
       if (packageScopeOwner === true) {
+        this.logger.debug('[gitlab] user:', user.name, 'allowed to publish package:', _package.name, 'as owner of package-scope');
         return cb(null, false);
       } else {
+        this.logger.debug('[gitlab] user:', user.name, 'denied from publishing package:', _package.name);
         if (_package.name.indexOf('@') === 0) {
           return cb(httperror[403]('must be owner of package-scope'));
         } else {


### PR DESCRIPTION
- avoid 'npm adduser' succeeding even when authentication fails
- store a proper authToken in .npmrc after successful login, avoid
  deprecation messages in login procedure
- adapt code to newer ecmascript standards
- improve logging messages
- editorconfig linting ignores anything not in git