### PR TITLE
refactor: add configurable authentication cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ your `~/.config/verdaccio/config.yaml` to use this plugin
 auth:
   gitlab:
     url: https://gitlab.com
+    authCache:
+      enabled: true
+      ttl: 300
 
 packages:
   '@*/*':
@@ -71,6 +74,34 @@ npm publish --registry http://localhost:4873
 ```
 
 > **NOTE**: you need a fresh login, so that verdaccio recognizes your owned groups
+
+## Authentication Cache
+
+In order to avoid too many authentication requests to the underlying
+gitlab instance, the plugin provides an in-memory cache that will save
+the detected groups of the users for a configurable ttl in seconds.
+No clear-text password will be saved in-memory, just an SHA-256 hash
+and the groups information.
+
+By default, the cache will be enabled and the credentials will be stored
+for 300 seconds. The ttl is checked on access, but there's also an
+internal timer that will check expired values regularly, so data of
+users not actively interacting with the system will also be eventually
+invalidated.
+
+```yaml
+auth:
+  gitlab:
+    url: https://gitlab.com
+    authCache:
+      enabled: (default true)
+      ttl: (default: 300)
+```
+
+*Please note* that this implementation is in-memory and not
+multi-process; if the cluster module is used for starting several
+verdaccio processes, each process will store its own copy of the cache,
+so each user will actually be logged in multiple times.
 
 ## Docker
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "babel src/ --out-dir lib/ --copy-files --ignore ___tests___ --source-maps",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "license": "license-checker --onlyAllow 'Apache-2.0; BSD; BSD-2-Clause; BSD-3-Clause; ISC; MIT; Unlicense; WTFPL; CC-BY-3.0; CC0-1.0' --production",
-    "lint": "eslint index.js && eclint check $(git ls-files) && markdownlint README.md",
+    "lint": "eslint src/index.js && eclint check $(git ls-files) && markdownlint README.md",
     "prepublish": "in-publish && npm run lint && npm run build || not-in-publish",
     "release:major": "changelog -M && git commit -a -m 'docs: updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",
     "release:minor": "changelog -m && git commit -a -m 'docs: updated CHANGELOG.md' && npm version minor && git push origin && git push origin --tags",
@@ -47,6 +47,7 @@
     "gitlab": "^3.4.2",
     "global-tunnel-ng": "^2.1.1",
     "http-errors": "^1.6.3",
+    "node-cache": "^4.2.0",
     "verdaccio": "^3.1.1"
   },
   "devDependencies": {

--- a/src/authcache.js
+++ b/src/authcache.js
@@ -1,0 +1,59 @@
+// Copyright 2018 Roger Meier <roger@bufferoverflow.ch>
+// SPDX-License-Identifier: MIT
+// @flow
+
+import NodeCache from 'node-cache';
+import type { Logger } from '@verdaccio/types';
+import Crypto from 'crypto';
+
+export class AuthCache {
+  logger: Logger;
+  ttl: number;
+  storage: NodeCache;
+
+  static get DEFAULT_TTL() { return 300; }
+
+  constructor(logger: Logger, ttl: number) {
+    this.logger = logger;
+    this.ttl = ttl || AuthCache.DEFAULT_TTL;
+
+    this.storage = new NodeCache({
+      stdTTL: this.ttl,
+      useClones: false
+    });
+    this.storage.on('expired', (key, value) => {
+      if (this.logger.trace()) {
+        this.logger.trace('[gitlab] expired key:', key, 'with value:', value);
+      }
+    });
+  }
+
+  findUser(username: string, password: string): UserData {
+    return this.storage.get(this._generateKeyHash(username, password));
+  }
+
+  storeUser(username: string, password: string, userData: UserData): boolean {
+    return this.storage.set(this._generateKeyHash(username, password), userData);
+  }
+
+  _generateKeyHash(username: string, password: string) {
+    const sha = Crypto.createHash('sha256');
+    sha.update(JSON.stringify({ username: username, password: password }));
+    return sha.digest('hex');
+  }
+
+}
+
+export class UserData {
+  _username: string;
+  _groups: string[];
+
+  get username(): string { return this._username; }
+  get groups(): string[] { return this._groups; }
+  set groups(groups: string[]) { this._groups = groups; }
+
+  constructor(username: string, groups: string[]) {
+    this._username = username;
+    this._groups = groups;
+  }
+}


### PR DESCRIPTION
avoid too many auth requests to the gitlab server by storing
the users owned groups in-memory for a configurable period

Closes #13