### PR TITLE
chore: drop node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 'lts/boron'
   - 'lts/carbon'
   - 'lts/*'
 script:


### PR DESCRIPTION
drop node 6 support in preparation for yarn migration