### PR TITLE
refactor(gitlab): simplify allow_publish function

### DIFF
--- a/src/authcache.js
+++ b/src/authcache.js
@@ -42,7 +42,6 @@ export class AuthCache {
     sha.update(JSON.stringify({ username: username, password: password }));
     return sha.digest('hex');
   }
-
 }
 
 export type UserDataGroups = {


### PR DESCRIPTION
This PR simplifies the allow_publish by keeping the same functionality.
Removes unnecessary over-nesting and minor code duplication.
Makes minor white-space arrangements.