### PR TITLE
chore: upgrade verdaccio to latest stable 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "global-tunnel-ng": "2.5.3",
     "http-errors": "1.6.3",
     "node-cache": "4.2.0",
-    "verdaccio": "3.8.6"
+    "verdaccio": "4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "7.0.0",


### PR DESCRIPTION
Just thought it would be nice to upgrade Verdaccio to the latest stable.