### PR TITLE
feat: allow white listing groups

### DIFF
--- a/src/authcache.js
+++ b/src/authcache.js
@@ -14,15 +14,15 @@ export class AuthCache {
 
   static get DEFAULT_TTL() { return 300; }
 
-  static _generateKeyHash(username: string, password: string) {
+  static _generateKeyHash(username: string) {
     const sha = Crypto.createHash('sha256');
-    sha.update(JSON.stringify({ username: username, password: password }));
+    sha.update(JSON.stringify({ username: username }));
     return sha.digest('hex');
   }
 
   constructor(logger: Logger, ttl?: number) {
     this.logger = logger;
-    this.ttl = ttl || AuthCache.DEFAULT_TTL;
+    this.ttl = ttl <= 0 ? AuthCache.DEFAULT_TTL : ttl || AuthCache.DEFAULT_TTL;
 
     this.storage = new NodeCache({
       stdTTL: this.ttl,
@@ -35,17 +35,18 @@ export class AuthCache {
     });
   }
 
-  findUser(username: string, password: string): UserData {
-    return this.storage.get(AuthCache._generateKeyHash(username, password));
+  findUser(username: string): UserData {
+    return this.storage.get(AuthCache._generateKeyHash(username));
   }
 
-  storeUser(username: string, password: string, userData: UserData): boolean {
-    return this.storage.set(AuthCache._generateKeyHash(username, password), userData);
+  storeUser(username: string, userData: UserData): boolean {
+    return this.storage.set(AuthCache._generateKeyHash(username), userData);
   }
 }
 
 export type UserDataGroups = {
-  publish: string[]
+  publish: Array<string>,
+  access: Array<string>
 };
 
 export class UserData {

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -8,6 +8,7 @@ import type { UserDataGroups } from './authcache';
 import Gitlab from 'gitlab';
 import { AuthCache, UserData } from './authcache';
 import httperror from 'http-errors';
+import { normalizeYamlSetting } from './utils';
 
 export type VerdaccioGitlabAccessLevel =
   '$guest' |
@@ -19,16 +20,17 @@ export type VerdaccioGitlabAccessLevel =
 export type VerdaccioGitlabConfig = {
   url: string,
   authCache?: {
-    enabled?: boolean,
     ttl?: number
   },
   legacy_mode?: boolean,
+  access?: VerdaccioGitlabAccessLevel,
   publish?: VerdaccioGitlabAccessLevel
 };
 
 export type VerdaccioGitlabPackageAccess = PackageAccess & {
   name: string,
-  gitlab?: boolean
+  gitlab?: boolean,
+  gitlabUserGroupWhitelist?: any
 }
 
 const ACCESS_LEVEL_MAPPING = {
@@ -51,6 +53,7 @@ export default class VerdaccioGitLab implements IPluginAuth {
   config: VerdaccioGitlabConfig;
   authCache: AuthCache;
   logger: Logger;
+  accessLevel: VerdaccioGitlabAccessLevel;
   publishLevel: VerdaccioGitlabAccessLevel;
 
   constructor(config: VerdaccioGitlabConfig, options: PluginOptions) {
@@ -59,26 +62,33 @@ export default class VerdaccioGitLab implements IPluginAuth {
     this.options = options;
     this.logger.info(`[gitlab] url: ${this.config.url}`);
 
-    if ((this.config.authCache || {}).enabled === false) {
-      this.logger.info('[gitlab] auth cache disabled');
-    } else {
-      const ttl = (this.config.authCache || {}).ttl || AuthCache.DEFAULT_TTL;
-      this.authCache = new AuthCache(this.logger, ttl);
-      this.logger.info(`[gitlab] initialized auth cache with ttl: ${ttl} seconds`);
-    }
+    const ttl = (this.config.authCache || {}).ttl || AuthCache.DEFAULT_TTL;
+    this.authCache = new AuthCache(this.logger, ttl);
+    this.logger.info(`[gitlab] initialized auth cache with ttl: ${ttl} seconds`);
 
     if (this.config.legacy_mode) {
       this.publishLevel = '$owner';
       this.logger.info('[gitlab] legacy mode pre-gitlab v11.2 active, publish is only allowed to group owners');
     } else {
-      this.publishLevel = '$maintainer';
       if (this.config.publish) {
         this.publishLevel = this.config.publish;
+      } else {
+        this.publishLevel = '$maintainer';
       }
 
+      if (this.config.access) {
+        this.accessLevel = this.config.access;
+      } else {
+        this.accessLevel = '$maintainer';
+      }
+
+      if (!Object.keys(ACCESS_LEVEL_MAPPING).includes(this.accessLevel)) {
+        throw Error(`[gitlab] invalid access access level configuration: ${this.accessLevel}`);
+      }
       if (!Object.keys(ACCESS_LEVEL_MAPPING).includes(this.publishLevel)) {
         throw Error(`[gitlab] invalid publish access level configuration: ${this.publishLevel}`);
       }
+      this.logger.info(`[gitlab] access control level: ${this.accessLevel}`);
       this.logger.info(`[gitlab] publish control level: ${this.publishLevel}`);
     }
   }
@@ -90,7 +100,7 @@ export default class VerdaccioGitLab implements IPluginAuth {
     const cachedUserGroups = this._getCachedUserGroups(user, password);
     if (cachedUserGroups) {
       this.logger.debug(`[gitlab] user: ${user} found in cache, authenticated with groups:`, cachedUserGroups);
-      return cb(null, cachedUserGroups.publish);
+      return cb(null, [user]);
     }
 
     // Not found in cache, query gitlab
@@ -107,6 +117,7 @@ export default class VerdaccioGitLab implements IPluginAuth {
       }
 
       const publishLevelId = ACCESS_LEVEL_MAPPING[this.publishLevel];
+      const accessLevelId = ACCESS_LEVEL_MAPPING[this.accessLevel];
 
       // Set the groups of an authenticated user, in normal mode:
       // - for access, depending on the package settings in verdaccio
@@ -115,25 +126,35 @@ export default class VerdaccioGitLab implements IPluginAuth {
       // In legacy mode, the groups are:
       // - for access, depending on the package settings in verdaccio
       // - for publish, the logged in user id and all the groups they can reach as fixed `$auth.gitlab.publish` = `$owner`
+      const gitlabAccessQueryParams = this.config.legacy_mode ? { owned: true } : { min_access_level: accessLevelId };
       const gitlabPublishQueryParams = this.config.legacy_mode ? { owned: true } : { min_access_level: publishLevelId };
       this.logger.trace('[gitlab] querying gitlab user groups with params:', gitlabPublishQueryParams);
 
-      const groupsPromise = GitlabAPI.Groups.all(gitlabPublishQueryParams).then(groups => {
+      const accessGroupsPromise = GitlabAPI.Groups.all(gitlabAccessQueryParams).then(groups => {
+        return groups.filter(group => group.path === group.full_path).map(group => group.path);
+      });
+      const publishGroupsPromise = GitlabAPI.Groups.all(gitlabPublishQueryParams).then(groups => {
         return groups.filter(group => group.path === group.full_path).map(group => group.path);
       });
 
-      const projectsPromise = GitlabAPI.Projects.all(gitlabPublishQueryParams).then(projects => {
+      const accessProjectsPromise = GitlabAPI.Projects.all(gitlabAccessQueryParams).then(projects => {
+        return projects.map(project => project.path_with_namespace);
+      });
+      const publishProjectsPromise = GitlabAPI.Projects.all(gitlabPublishQueryParams).then(projects => {
         return projects.map(project => project.path_with_namespace);
       });
 
-      Promise.all([groupsPromise, projectsPromise]).then(([groups, projectGroups]) => {
-        const realGroups = [user, ...groups, ...projectGroups];
-        this._setCachedUserGroups(user, password, { publish: realGroups });
+      Promise.all([accessGroupsPromise, publishGroupsPromise, accessProjectsPromise, publishProjectsPromise]).then(([accessGroups, publishGroups, accessProjectGroups, publishProjectGroups]) => {
+        const realAccessGroups = [user, ...accessGroups, ...accessProjectGroups];
+        const realPublishGroups = [user, ...publishGroups, ...publishProjectGroups];
+        this._setCachedUserGroups(user, {access: realAccessGroups, publish: realPublishGroups});
 
         this.logger.info(`[gitlab] user: ${user} successfully authenticated`);
-        this.logger.debug(`[gitlab] user: ${user}, with groups:`, realGroups);
+        this.logger.debug(`[gitlab] user: ${user}, with groups:`, realPublishGroups);
 
-        return cb(null, realGroups);
+        // The actual implementation of Verdaccio's plugin does not allow us to differentiate access and publish at this point.
+        // We'll use the cache to bypass that for now. For that reason, it does not matter what groups we return here.
+        return cb(null, [user]);
       }).catch(error => {
         this.logger.error(`[gitlab] user: ${user} error querying gitlab: ${error}`);
         return cb(httperror[401]('error authenticating user'));
@@ -156,8 +177,33 @@ export default class VerdaccioGitLab implements IPluginAuth {
     const packageAccess = (_package.access && _package.access.length > 0) ? _package.access : DEFAULT_ALLOW_ACCESS_LEVEL;
 
     if (user.name !== undefined) { // successfully authenticated
-      this.logger.debug(`[gitlab] allow user: ${user.name} authenticated access to package: ${_package.name}`);
-      return cb(null, true);
+
+      if (_package.gitlabUserGroupWhitelist) {
+        const cachedUserGroups = this._getCachedUserGroups(user.name);
+        if (!cachedUserGroups) {
+          this.logger.debug(`[gitlab] no user found in cache for this username: ${user.name}`);
+          return cb(httperror[401]('access denied, user found'));
+        }
+
+        let userGroups = cachedUserGroups.access;
+
+        this.logger.trace(`[gitlab] access: checking group whitelist for user: ${user.name || ''} and package: ${_package.name}`);
+
+        const gitlabUserGroupWhitelist = normalizeYamlSetting(_package.gitlabUserGroupWhitelist);
+
+        for (let whitelistedGroup of gitlabUserGroupWhitelist) {
+          if (userGroups.indexOf(whitelistedGroup) !== -1) {
+            this.logger.debug(`[gitlab] user: ${user.name || ''} allowed to access package: ${_package.name} based on group whitelist ${whitelistedGroup}`);
+            return cb(null, true);
+          }
+        }
+
+        this.logger.debug(`[gitlab] deny access to package: ${_package.name}`);
+        return cb(httperror[401]('access denied, user is not member of any of the whitelisted groups'));
+      } else {
+        this.logger.debug(`[gitlab] allow user: ${user.name} authenticated access to package: ${_package.name}`);
+        return cb(null, true);
+      }
     } else { // unauthenticated
       if (BUILTIN_ACCESS_LEVEL_ANONYMOUS.some(level => packageAccess.includes(level))) {
         this.logger.debug(`[gitlab] allow anonymous access to package: ${_package.name}`);
@@ -172,6 +218,30 @@ export default class VerdaccioGitLab implements IPluginAuth {
   allow_publish(user: RemoteUser, _package: VerdaccioGitlabPackageAccess, cb: Callback) {
     if (!_package.gitlab) return cb(null, false);
 
+    if (_package.gitlabUserGroupWhitelist) {
+      const cachedUserGroups = this._getCachedUserGroups(user.name);
+      if (!cachedUserGroups) {
+        this.logger.debug(`[gitlab] no user found in cache for this username: ${user.name}`);
+        return cb(httperror[401]('publish denied, user found'));
+      }
+
+      let userGroups = cachedUserGroups.publish;
+
+      this.logger.trace(`[gitlab] publish: checking group whitelist for user: ${user.name || ''} and package: ${_package.name}`);
+
+      const gitlabUserGroupWhitelist = normalizeYamlSetting(_package.gitlabUserGroupWhitelist);
+
+      for (let whitelistedGroup of gitlabUserGroupWhitelist) {
+        if (userGroups.indexOf(whitelistedGroup) !== -1) {
+          this.logger.debug(`[gitlab] user: ${user.name || ''} allowed to publish package: ${_package.name} based on group whitelist ${whitelistedGroup}`);
+          return cb(null, true);
+        }
+      }
+
+      this.logger.debug(`[gitlab] deny publish to package: ${_package.name}`);
+      return cb(httperror[401]('publish denied, user is not member of any of the whitelisted groups'));
+    }
+    
     let packageScopePermit = false;
     let packagePermit = false;
     // Only allow to publish packages when:
@@ -222,19 +292,13 @@ export default class VerdaccioGitLab implements IPluginAuth {
     return false;
   }
 
-  _getCachedUserGroups(username: string, password: string): ?UserDataGroups {
-    if (!this.authCache) {
-      return null;
-    }
-    const userData = this.authCache.findUser(username, password);
+  _getCachedUserGroups(username: string): ?UserDataGroups {
+    const userData = this.authCache.findUser(username);
     return (userData || {}).groups || null;
   }
 
-  _setCachedUserGroups(username: string, password: string, groups: UserDataGroups): boolean {
-    if (!this.authCache) {
-      return false;
-    }
+  _setCachedUserGroups(username: string, groups: UserDataGroups): boolean {
     this.logger.debug(`[gitlab] saving data in cache for user: ${username}`);
-    return this.authCache.storeUser(username, password, new UserData(username, groups));
+    return this.authCache.storeUser(username, new UserData(username, groups));
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,23 @@
+import httperror from 'http-errors';
+import _ from "lodash";
+
+/**
+ * Normalize a Yaml setting, allowing to pass a single word or a list of words separated by spaces.
+ * Heavily inspired by the normalizeUserList function from Verdaccio.
+ * @return {Array}
+ */
+export function normalizeYamlSetting(setting: any) {
+  const result = [];
+  /* eslint prefer-rest-params: "off" */
+
+  // if it's a string, split it to array
+  if (_.isString(setting)) {
+    result.push(setting.split(/\s+/));
+  } else if (Array.isArray(setting)) {
+    result.push(setting);
+  } else {
+    throw httperror('CONFIG: bad package acl (array or string expected): ' + JSON.stringify(setting));
+  }
+
+  return _.flatten(result);
+}

--- a/test/unit/authcache.spec.js
+++ b/test/unit/authcache.spec.js
@@ -22,8 +22,8 @@ describe('AuthCache Unit Tests', () => {
   test('should store and find some user data', () => {
     const authCache: AuthCache = new AuthCache(logger);
 
-    authCache.storeUser(config.user, config.pass, config.userData);
-    const returnedData: UserData = authCache.findUser(config.user, config.pass);
+    authCache.storeUser(config.user, config.userData);
+    const returnedData: UserData = authCache.findUser(config.user);
 
     expect(returnedData).toEqual(config.userData);
   });
@@ -32,8 +32,8 @@ describe('AuthCache Unit Tests', () => {
     const UNLIMITED_TTL: number = 0;
     const authCache: AuthCache = new AuthCache(logger, UNLIMITED_TTL);
 
-    authCache.storeUser(config.user, config.pass, config.userData);
-    const returnedData: UserData = authCache.findUser(config.user, config.pass);
+    authCache.storeUser(config.user, config.userData);
+    const returnedData: UserData = authCache.findUser(config.user);
 
     expect(returnedData).toEqual(config.userData);
   });

--- a/test/unit/partials/config/index.js
+++ b/test/unit/partials/config/index.js
@@ -27,7 +27,8 @@ const remoteUser: RemoteUser = {
 };
 
 const userDataGroups: UserDataGroups = {
-  publish: ['fooGroup1', 'fooGroup2']
+  publish: ['fooGroup1', 'fooGroup2'],
+  access: ['fooGroup1', 'fooGroup2'],
 };
 const userData: UserData = new UserData(user, userDataGroups);
 


### PR DESCRIPTION
We recently forked a repository which uses Lerna. Say the main package is called A and has "sub-packages" called B and C. With this plugin's current implementation of permissions, we would only have been able to publish our updated versions of A, but not B nor C, because the project's repository is called A.

This PR allows to add an option `gitlabUserGroupWhitelist` (which is a space-separated list) at the package level, to allow to bypass the usual permissions checks if the user belongs to any of the specified groups. For example :

```
packages:
  '**':
    access: $authenticated
    publish: $authenticated
    proxy: npmjs
    gitlab: true
    gitlabUserGroupWhitelist: org_name
```

This allows us to grant access to all members of our organization, regardless of the projects naming scheme.