### PR TITLE
fix: Allows matching of mixed-case usernames

### DIFF
--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -102,7 +102,7 @@ export default class VerdaccioGitLab implements IPluginAuth {
     });
 
     GitlabAPI.Users.current().then(response => {
-      if (user !== response.username) {
+      if (user !== response.username.toLowerCase()) {
         return cb(httperror[401]('wrong gitlab username'));
       }
 


### PR DESCRIPTION
Fixes #20 
GitLab will now return a user through case-agnostic matching, so I updated a line to accommodate this within the plugin.