### PR TITLE
fix(auth): allows matching of mixed-case usernames

### DIFF
--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -97,7 +97,7 @@ export default class VerdaccioGitLab implements VerdaccioGitLabPlugin {
 
     GitlabAPI.Users.current()
       .then(response => {
-        if (user !== response.username.toLowerCase()) {
+        if (user.toLowerCase() !== response.username.toLowerCase()) {
           return cb(getUnauthorized('wrong gitlab username'));
         }
 

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -97,7 +97,7 @@ export default class VerdaccioGitLab implements VerdaccioGitLabPlugin {
 
     GitlabAPI.Users.current()
       .then(response => {
-        if (user !== response.username) {
+        if (user !== response.username.toLowerCase()) {
           return cb(getUnauthorized('wrong gitlab username'));
         }
 


### PR DESCRIPTION
Fixes #20 
Allow inserting the lowercase version of the Gitlab username, since it's accepted by the Gitlab API.

GitLab will now return a user through case-agnostic matching.

Based on #96 